### PR TITLE
Disable drop and individual items

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ import Reorder, {
   onReorder={this.onReorder.bind(this)} // Callback when an item is dropped (you will need this to update your state)
   autoScroll={true} // Enable auto-scrolling when the pointer is close to the edge of the Reorder component (optional), defaults to true
   disabled={false} // Disable reordering (optional), defaults to false
-  disableContextMenus={true} // Disable context menus when holding on 
-  disableDrop={false} // Disable accepting drop (and reorder) to use as a draggable source list
+  disableContextMenus={true} // Disable context menus when holding on touch devices (optional), defaults to true
+  disableDrop={false} // Disable accepting drop (and reorder) to use as a draggable source list (optional)
   placeholder={
     <div className="custom-placeholder" /> // Custom placeholder element (optional), defaults to clone of dragged element
   }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ import Reorder, {
   onReorder={this.onReorder.bind(this)} // Callback when an item is dropped (you will need this to update your state)
   autoScroll={true} // Enable auto-scrolling when the pointer is close to the edge of the Reorder component (optional), defaults to true
   disabled={false} // Disable reordering (optional), defaults to false
-  disableContextMenus={true} // Disable context menus when holding on touch devices (optional), defaults to true
+  disableContextMenus={true} // Disable context menus when holding on 
+  disableDrop={false} // Disable accepting drop (and reorder) to use as a draggable source list
   placeholder={
     <div className="custom-placeholder" /> // Custom placeholder element (optional), defaults to clone of dragged element
   }

--- a/examples/src/js/grid.js
+++ b/examples/src/js/grid.js
@@ -45,13 +45,15 @@ export class Grid extends Component {
           onReorder={this.onReorder.bind(this)}
         >
           {
-            this.state.list.map(({name, color}) => (
+            this.state.list.map(({name, color}, idx) => (
               <li
+                disabled={idx === 0 || idx === 9}
                 key={name}
                 className={[classNames.listItem, classNames.listItem3].join(' ')}
                 style={{color: color}}
               >
                 {name}
+                {(idx === 0 || idx === 9) && ' (disabled)'}
               </li>
             )).toArray()
           }

--- a/src/index.js
+++ b/src/index.js
@@ -246,7 +246,7 @@
     function startDrag (reorderId, reorderGroup, index, element, component) {
       target = component;
 
-      // Disable draggin for items with [disabled] props
+      // Disable dragging for items with [disabled] props
       if (element.props.disabled) {
         return;
       }
@@ -488,6 +488,7 @@
 
       findCollisionIndex: function (event, listElements) {
         for (var i = 0; i < listElements.length; i += 1) {
+          // Skip placeholders, current and disabled items
           if (
             !listElements[i].getAttribute('data-placeholder')
             && !listElements[i].getAttribute('data-dragged')

--- a/src/index.js
+++ b/src/index.js
@@ -246,6 +246,11 @@
     function startDrag (reorderId, reorderGroup, index, element, component) {
       target = component;
 
+      // Disable draggin for items with [disabled] props
+      if (element.props.disabled) {
+        return;
+      }
+
       clearInterval(scrollInterval);
       scrollInterval = setInterval(autoScroll, CONSTANTS.SCROLL_INTERVAL);
 
@@ -483,7 +488,11 @@
 
       findCollisionIndex: function (event, listElements) {
         for (var i = 0; i < listElements.length; i += 1) {
-          if (!listElements[i].getAttribute('data-placeholder') && !listElements[i].getAttribute('data-dragged')) {
+          if (
+            !listElements[i].getAttribute('data-placeholder')
+            && !listElements[i].getAttribute('data-dragged')
+            && !listElements[i].hasAttribute('disabled')
+          ) {
 
             var rect = listElements[i].getBoundingClientRect();
 
@@ -751,8 +760,8 @@
         var placeholderElement = this.props.placeholder || this.state.draggedElement;
 
         if (this.props.disableDrop) {
-          // Render item clone at the same position
-          if (this.isPlacing()) {
+          // Only render item clone at the same position when draggin from the list
+          if (this.isPlacing() && this.isDraggingFrom()) {
             var placeholder = React.cloneElement(
               this.state.draggedElement,
               {

--- a/src/index.js
+++ b/src/index.js
@@ -627,7 +627,7 @@
           this.moved = true;
         }
 
-        if (this.isDragging() && this.isInvolvedInDragging()) {
+        if (!this.props.disableDrop && this.isDragging() && this.isInvolvedInDragging()) {
           this.preventNativeScrolling(event);
 
           var element = this.rootNode;
@@ -750,17 +750,33 @@
 
         var placeholderElement = this.props.placeholder || this.state.draggedElement;
 
-        if (this.isPlacing() && this.isPlacingTo() && placeholderElement) {
-          var placeholder = React.cloneElement(
-            placeholderElement,
-            {
-              key: 'react-reorder-placeholder',
-              className: [placeholderElement.props.className || '', this.props.placeholderClassName].join(' '),
-              'data-placeholder': true
-            }
-          );
+        if (this.props.disableDrop) {
+          // Render item clone at the same position
+          if (this.isPlacing()) {
+            var placeholder = React.cloneElement(
+              this.state.draggedElement,
+              {
+                key: 'react-reorder-placeholder',
+                className: [placeholderElement.props.className || '', this.props.placeholderClassName].join(' '),
+                'data-placeholder': true
+              }
+            );
 
-          children.splice(this.state.placedIndex, 0, placeholder);
+            children.splice(this.state.draggedIndex, 0, placeholder);
+          }
+        } else {
+          if (this.isPlacing() && this.isPlacingTo() && placeholderElement) {
+            var placeholder = React.cloneElement(
+              placeholderElement,
+              {
+                key: 'react-reorder-placeholder',
+                className: [placeholderElement.props.className || '', this.props.placeholderClassName].join(' '),
+                'data-placeholder': true
+              }
+            );
+
+            children.splice(this.state.placedIndex, 0, placeholder);
+          }
         }
 
         return React.createElement(
@@ -797,7 +813,8 @@
       autoScroll: PropTypes.bool,
       autoScrollParents: PropTypes.bool,
       disabled: PropTypes.bool,
-      disableContextMenus: PropTypes.bool
+      disableContextMenus: PropTypes.bool,
+      disableDrop: PropTypes.bool
     };
 
     Reorder.defaultProps = {
@@ -818,7 +835,8 @@
       // This is very slow if nested > 8 levels deep in DOM, avoid using
       autoScrollParents: false,
       disabled: false,
-      disableContextMenus: true
+      disableContextMenus: true,
+      disableDrop: false
     };
 
     return Reorder;


### PR DESCRIPTION
- Added new `disableDrop` property support on `reorder` component that would not allow it accepting drops (and rendering placeholder). This is to be used for “source” lists to clone items **from**, to add to the results list.
- Added support for `disabled` attribute on any item. This is to “lock” certain items in place, not allowing re-arrangements for them (or placing other items before or after them if they are in the beginning or end of the list).